### PR TITLE
Adding discord and instagram link shortcodes

### DIFF
--- a/layouts/shortcodes/discord_link.html
+++ b/layouts/shortcodes/discord_link.html
@@ -1,3 +1,1 @@
-{{- $default := index site.Params "discord_label" -}}
-{{- $name := or ($.Get "param1") $default -}}
-[{{ $name }}](https://discord.gg/{{ index site.Params "discord" }})
+https://discord.gg/{{- index site.Params "discord" -}}

--- a/layouts/shortcodes/discord_link.html
+++ b/layouts/shortcodes/discord_link.html
@@ -1,0 +1,3 @@
+{{- $default := index site.Params "discord_label" -}}
+{{- $name := or ($.Get "param1") $default -}}
+[{{ $name }}](https://discord.gg/{{ index site.Params "discord" }})

--- a/layouts/shortcodes/instagram_link.html
+++ b/layouts/shortcodes/instagram_link.html
@@ -1,0 +1,3 @@
+{{- $default := index site.Params "instagram_label" -}}
+{{- $name := or ($.Get "param1") $default -}}
+[{{ $name }}](https://instagram.com/{{ index site.Params "instagram" }})

--- a/layouts/shortcodes/instagram_link.html
+++ b/layouts/shortcodes/instagram_link.html
@@ -1,3 +1,1 @@
-{{- $default := index site.Params "instagram_label" -}}
-{{- $name := or ($.Get "param1") $default -}}
-[{{ $name }}](https://instagram.com/{{ index site.Params "instagram" }})
+https://instagram.com/{{- index site.Params "instagram" -}}


### PR DESCRIPTION
Adding shortcodes to construct discord and instagram links using the `discord` and `instagram` params from the user's hugo.toml.

The default label can be set using the `<platform>_label` param in the user's hugo.toml.

These can be used in the content markdown files via `{{% instagram_link %}}` or `{{% instagram_link param1="Check out our instagram!" %}}` for a custom link label.